### PR TITLE
build: add static hitch vendor scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # hylance
 Kubernetes  ingress controller for fast IoT SSL termination with  mTLS support
+
+This repository also contains `plan.md`, which outlines a hybrid ingress controller
+built from the Hitch TLS proxy and the Balance TCP load balancer. The plan
+covers steps for feasibility evaluation, architecture, Kubernetes integration,
+and deployment.
+
+## Progress
+
+- `step1-results.md` describes current build attempts for Hitch and Balance.
+- `architecture.md` outlines the proposed single-binary design.
+- `k8s-integration.md` shows the planned CRD and controller approach.
+- `integration.md` covers merging the sources and performance considerations.
+- `documentation.md` notes contribution guidelines and licensing.
+
+## Static Hitch Build
+The `vendor/libev` directory contains a helper script to fetch and build a static
+`libev` suitable for linking Hitch statically. Run:
+
+```sh
+(cd vendor/libev && ./download.sh)
+(cd tls && ./static-build.sh)
+```
+
+This will produce a static `hitch` binary using the local libev.
+

--- a/architecture.md
+++ b/architecture.md
@@ -1,0 +1,17 @@
+# Step 2 Architecture
+This document sketches how Hitch and Balance can be linked into a single binary.
+
+## Layers
+1. **TLS termination** via Hitch's SSL library wrappers.
+2. **TCP load balancing** reusing Balance's event loop and connection manager.
+
+A wrapper binary will initialize Hitch, accept connections, decrypt TLS, then
+pass the plain TCP streams into Balance's balancer functions. This avoids extra
+socket hops.
+
+## Configuration
+A unified YAML file will specify:
+- Listener addresses and TLS certificates
+- Backend servers and balancing strategy
+
+The controller will translate Kubernetes Ingress objects into this file.

--- a/documentation.md
+++ b/documentation.md
@@ -1,0 +1,4 @@
+# Step 5 Documentation
+All documentation lives in the repository so the open-source community can
+follow development. Contribution guidelines will describe the review process
+and reference the Hitch and Balance licenses.

--- a/integration.md
+++ b/integration.md
@@ -1,0 +1,7 @@
+# Step 4 Integration
+The Hitch and Balance sources will be placed in `tls` and `tcp` directories.
+Common connection handling code should be extracted into a shared module.
+
+Performance testing will use `perf` and `ab` to measure throughput after each
+significant refactor. If profiling reveals heavy cost in the handshake code,
+that portion may be rewritten in Rust with FFI bindings.

--- a/k8s-integration.md
+++ b/k8s-integration.md
@@ -1,0 +1,10 @@
+# Step 3 Kubernetes Integration
+The project will define a simple Custom Resource Definition (CRD) named `HylanceIngress`.
+It maps to a YAML config consumed by the wrapper binary.
+
+A controller written in Go will watch for standard `Ingress` objects and
+produce `HylanceIngress` resources. The controller will then mount the unified
+YAML file into the pod running the binary.
+
+Helm charts will provide templates for deploying the controller and the binary
+with RBAC rules and Service definitions.

--- a/step1-results.md
+++ b/step1-results.md
@@ -1,0 +1,15 @@
+# Step 1 Evaluation
+## Build Verification
+
+- `make -C tcp` built the **Balance** source successfully.
+- `./configure` for **Hitch** failed due to missing dependencies (`libev`).
+
+## Findings
+
+- Balance is small and compiles without external dependencies.
+- Hitch requires additional libraries which complicates static compilation.
+
+
+Since `libev` was not present on the system, a vendored copy is now managed
+under `vendor/libev`. The helper scripts there build a static library so Hitch
+can be linked without external dependencies.

--- a/tls/static-build.sh
+++ b/tls/static-build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Build Hitch with static libev from ../vendor/libev
+set -e
+EV_DIR="../vendor/libev"
+if [ ! -f "$EV_DIR/libev.a" ]; then
+  echo "libev.a not found; run $EV_DIR/download.sh first" >&2
+  exit 1
+fi
+CFLAGS="-static" LDFLAGS="$EV_DIR/libev.a" ./configure --disable-shared --enable-static
+make clean
+make

--- a/vendor/libev/README.md
+++ b/vendor/libev/README.md
@@ -1,0 +1,2 @@
+This directory is intended to hold a vendored copy of libev so Hitch can be built statically.
+Run ./download.sh to fetch the source code and build a static library locally.

--- a/vendor/libev/download.sh
+++ b/vendor/libev/download.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+VER=4.33
+URL="https://github.com/enki/libev/archive/refs/tags/v$VER.tar.gz"
+if [ ! -f libev-$VER.tar.gz ]; then
+  echo "Downloading libev $VER..."
+  curl -L "$URL" -o libev-$VER.tar.gz
+fi
+if [ ! -d libev-$VER ]; then
+  tar -xzf libev-$VER.tar.gz
+fi
+cd libev-$VER
+./autogen.sh || true
+./configure --disable-shared --enable-static CFLAGS="-fPIC"
+make
+cd ..
+cp libev-$VER/.libs/libev.a .


### PR DESCRIPTION
## Summary
- add vendor/libev helper scripts
- add static-build.sh for Hitch to link libev statically
- document static build process
- note new vendored dependency in step1-results

## Testing
- `make -C tcp`
- `(cd vendor/libev && ./download.sh)` *(fails: CONNECT tunnel failed)*
- `(cd tls && ./static-build.sh)` *(fails: libev.a not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843615e39ec832b849b9ae3f8c7bdef